### PR TITLE
Use rls as default rlsPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
             "string",
             "null"
           ],
-          "default": null,
+          "default": "rls",
           "description": "Path to rls executable (only required for rls developers)"
         },
         "rust-client.revealOutputChannelOn": {


### PR DESCRIPTION
When using `:CocInstall coc-rls` to install this extension, rls can't be started as expected. Use `rls` instead of `null` would fix this problem.

![image](https://user-images.githubusercontent.com/8850248/49330426-56e6d480-f5c9-11e8-801d-51b849ae292f.png)
