### PR TITLE
Delete rust.goto_def_racer_fallback config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,12 +204,6 @@
           "description": "Do not enable default Cargo features.",
           "scope": "resource"
         },
-        "rust.goto_def_racer_fallback": {
-          "type": "boolean",
-          "default": false,
-          "description": "Use racer as a fallback for goto def.",
-          "scope": "resource"
-        },
         "rust.racer_completion": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
`rust.goto_def_racer_fallback` was removed from rls in https://github.com/rust-lang/rls/commit/a6af35b6ce8b2aa895f0365c917ec1acec7af6eb