### PR TITLE
Patch for 111e12c by renaming language id from rust to rust-client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,17 @@
           "default": null,
           "description": "Rust channel to invoke rustup with. Ignored if rustup is disabled. By default, uses the same channel as your currently open project."
         },
+        "rust-client.trace.server": {
+          "type": "string",
+          "enum": [
+            "off",
+            "messages",
+            "verbose"
+          ],
+          "default": "off",
+          "description": "Traces the communication between VS Code and the Rust language server.",
+          "scope": "window"
+        },
         "rust.sysroot": {
           "type": [
             "string",
@@ -266,17 +277,6 @@
           "default": true,
           "description": "Show additional context in hover tooltips when available. This is often the type local variable declaration.",
           "scope": "resource"
-        },
-        "rust.trace.server": {
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the Rust language server.",
-          "scope": "window"
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ class ClientWorkspace {
     }
 
     // Create the language client and start the client.
-    this.lc = new LanguageClient('rust', 'Rust Language Server', serverOptions, clientOptions)
+    this.lc = new LanguageClient('rust-client', 'Rust Language Server', serverOptions, clientOptions)
 
     const promise = this.progressCounter()
 


### PR DESCRIPTION
Coc-rls stops working with a error message: "Unknown RLS configuration: `trace` ". 
This is the same problem as reported for rls-vscode in https://github.com/rust-lang/rls-vscode/issues/530. 
This PR fixes it by porting the patch for it. (https://github.com/rust-lang/rls-vscode/pull/539)