### PR TITLE
Update yarn.lock via yarn update

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -87,10 +87,10 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@chemzqm/neovim@4.3.24":
-  version "4.3.24"
-  resolved "https://registry.yarnpkg.com/@chemzqm/neovim/-/neovim-4.3.24.tgz#2c571b3dae6fcdfb81a648d9048db914a9d28f4b"
-  integrity sha512-10DesU4DjTZ/cwoBA8QyJfrn/6smyup5446xwLJBETTampM2JMtOvSKIubSjUbR9xiLyUbpV58COb9uv7PAtZQ==
+"@chemzqm/neovim@4.3.26":
+  version "4.3.26"
+  resolved "https://registry.yarnpkg.com/@chemzqm/neovim/-/neovim-4.3.26.tgz#ba137bfd0908c59e21d34dc34db3c9f23948f005"
+  integrity sha512-vo1JkGeVbKgRPArJPT46CW1AvYKn9t9zdFFn5iCX6T9qMLmcIu6fTH8bG1sMvsgum1+Smj5btNDNHtQAjUVbiA==
   dependencies:
     babel-eslint "^8.2.6"
     msgpack-lite "^0.1.26"
@@ -109,10 +109,10 @@
     tslint-config-prettier "^1.6.0"
     tslint-react "^3.2.0"
 
-"@types/node@^10.12.0":
-  version "10.12.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
-  integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
+"@types/node@^10.12.9":
+  version "10.14.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.4.tgz#1c586b991457cbb58fef51bc4e0cfcfa347714b5"
+  integrity sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -214,17 +214,18 @@ circular-json@^0.5.5:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.5.9.tgz#932763ae88f4f7dead7a0d09c8a51a4743a53b1d"
   integrity sha512-4ivwqHpIFJZBuhN3g/pEcdbnGUywkBblloGbkglyloVjjR3uT6tieI89MVOfbP2tHX5sgb01FuLgAOzebNlJNQ==
 
-coc.nvim@^0.0.28:
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.28.tgz#5078d1269d8ab79ece6d7bb8aa4df041b71c1ba9"
-  integrity sha512-OmJEuiJL/Otpp8h6t/Ck5SxXL5LMIlDDZpLlqe2HC3QyK0e65BgJEBo0mwtoeTGPD5WGusn99yhQT0Fjv3bk5w==
+coc.nvim@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/coc.nvim/-/coc.nvim-0.0.32.tgz#9965e94ca37d011c3fe5c78a474e3f49d059e642"
+  integrity sha512-dlK+zZ3hsa43Edx0taY663jIjcvnTHkpRQ2322OMzIyoVj9ySwN6FKh4NSU28TFlFNKW89bqnnmJitPdo8Qc2w==
   dependencies:
-    "@chemzqm/neovim" "4.3.24"
+    "@chemzqm/neovim" "4.3.26"
     debounce "^1.2.0"
     fast-diff "^1.2.0"
     fb-watchman "^2.0.0"
     find-up "^3.0.0"
     fuzzaldrin "^2.1.0"
+    fuzzaldrin-plus "^0.6.0"
     glob "^7.1.3"
     isuri "^2.0.3"
     jsonc-parser "^2.0.2"
@@ -233,13 +234,12 @@ coc.nvim@^0.0.28:
     mkdirp "^0.5.1"
     node-json-db "^0.9.1"
     node-serial "^0.1.1"
-    pify "^4.0.0"
+    pify "^4.0.1"
     semver "^5.6.0"
     tslib "^1.9.3"
     uuid "^3.3.2"
     vscode-languageserver-protocol "^3.13.0"
     vscode-languageserver-types "^3.13.0"
-    vscode-snippet-parser "^0.0.5"
     vscode-uri "^1.0.6"
     which "^1.3.1"
 
@@ -360,6 +360,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
+fuzzaldrin-plus@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz#832f6489fbe876769459599c914a670ec22947ee"
+  integrity sha1-gy9kifvodnaUWVmckUpnDsIpR+4=
 
 fuzzaldrin@^2.1.0:
   version "2.1.0"
@@ -600,7 +605,7 @@ path-parse@^1.0.5:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
 
-pify@^4.0.0:
+pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
@@ -760,10 +765,10 @@ tsutils@^2.13.1, tsutils@^2.27.2:
   dependencies:
     tslib "^1.8.1"
 
-typescript@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
-  integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
+typescript@^3.1.6:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
+  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -792,11 +797,6 @@ vscode-languageserver-types@3.13.0, vscode-languageserver-types@^3.13.0:
   version "3.13.0"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.13.0.tgz#b704b024cef059f7b326611c99b9c8753c0a18b4"
   integrity sha512-BnJIxS+5+8UWiNKCP7W3g9FlE7fErFw0ofP5BXJe7c2tl0VeWh+nNHFbwAS2vmVC4a5kYxHBjRy0UeOtziemVA==
-
-vscode-snippet-parser@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/vscode-snippet-parser/-/vscode-snippet-parser-0.0.5.tgz#86ff0439212265265283d9ca86ee1bd1e66fc322"
-  integrity sha512-iJ5e7g5sCQJ5LRt5nGWtw10oHj44a+6flLAYbGlA2Jbu32UQtjJqGnaT/1TzMV8Tlig/fsrHf7NoMlAT8N+FmA==
 
 vscode-uri@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
The yarn.lock file had gone out of sync with the package.json file. I
was getting errors like the following when trying to run the Yarn build.

```
Couldn't find any versions for "coc.nvim" that matches "^0.0.32" in our
cache (possible versions are ""). This is usually caused by a missing
entry in the lockfile, running Yarn without the --offline flag may help
fix this issue.
```