### PR TITLE
Remove deprecated setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,12 +182,6 @@
           "description": "Show warnings.",
           "scope": "resource"
         },
-        "rust.use_crate_blacklist": {
-          "type": "boolean",
-          "default": true,
-          "description": "Don't index crates on the crate blacklist.",
-          "scope": "resource"
-        },
         "rust.crate_blacklist": {
           "type": [
             "array",


### PR DESCRIPTION
```
[coc.nvim] RLS configuration option `use_crate_blacklist` is deprecated: use `crate_blacklist` instead
```

This pr removes the deprecated setting from the package.json