### PR TITLE
Remove `use_crate_blacklist` documentation, bump version to 1.1.3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -163,10 +163,6 @@ for auto completion support.
 
       	Show warnings.,  default: `true`
 
-- "rust.use_crate_blacklist":
-
-      	Don't index crates on the crate blacklist.,  default: `true`
-
 - "rust.crate_blacklist":
 
       Overrides the default list of packages for which analysis is skipped.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-rls",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Rust language support - code completion, Intellisense, refactoring, reformatting, errors, snippets. A client for the Rust Language Server, built by the RLS team.",
   "main": "lib/index.js",
   "publisher": "chemzqm",


### PR DESCRIPTION
Closes #44.