### PR TITLE
Update "rust.wait_to_build"

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -157,7 +157,7 @@ for auto completion support.
 
 - `"rust.wait_to_build"`:
 
-  Time in milliseconds between receiving a change notification and starting build.,  default: `1500`
+  Time in milliseconds between receiving a change notification and starting build.,  default: `null`
 
 - `"rust.show_warnings"`:
 

--- a/package.json
+++ b/package.json
@@ -171,8 +171,11 @@
           "scope": "resource"
         },
         "rust.wait_to_build": {
-          "type": "number",
-          "default": 1500,
+          "type": [
+              "number",
+              "null"
+          ],
+          "default": null,
           "description": "Time in milliseconds between receiving a change notification and starting build.",
           "scope": "resource"
         },


### PR DESCRIPTION
This update speeds up lint for many users who do not explicitly set "rust.wait_to_build".

See "rls-vscode": https://github.com/rust-lang/rls-vscode/commit/488ee9013d25e75e1ad0e2ced57ce47d7b74573f