### PR TITLE
Updates Readme.md improving the nixos documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -54,7 +54,8 @@ NixOS users should use nix-shell or direnv for development. Follow [these instru
 Then create two files:
 
 1. An **.envrc** file containing `use_nix`.
-2. And **shell.nix** containing:
+2. Add `"rust-client.disableRustup": true` to `coc-settings.json`
+3. And **shell.nix** containing:
 
 ```
 let


### PR DESCRIPTION
This instructs the user to disable rustup in the coc-settings.json.
Rustup doesn't work well on nixos and isn't needed if the other
instructions here are followed. This commit also fixes #32