### PR TITLE
Add `rust-client.enable` option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,6 +92,10 @@ This extension provides some options into `coc-settings.json`. These
 options have names which start with `rust.`. Install [coc-json](https://github.com/neoclide/coc-json)
 for auto completion support.
 
+- `"rust-client.enable"`:
+
+  When set to true, enables this extension. Requires reloading extension after change., default: `true`
+
 - `"rust-client.logToFile"`:
 
   When set to true, RLS stderr is logged to a file at workspace root level. Requires reloading extension after change., default: `false`

--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
       "type": "object",
       "title": "Rust configuration",
       "properties": {
+        "rust-client.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "When set to true, enables this extension. Requires reloading extension after change."
+        },
         "rust-client.logToFile": {
           "type": "boolean",
           "default": false,

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -29,6 +29,10 @@ function fromStringToRevealOutputChannelOn(value: string): RevealOutputChannelOn
 }
 
 export class RLSConfiguration {
+  public get enable(): boolean {
+    return this.configuration.get<boolean>('rust-client.enable', true)
+  }
+
   public get rustupPath(): string {
     return this.configuration.get('rust-client.rustupPath', 'rustup')
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,14 @@ export async function activate(context: ExtensionContext): Promise<void> {
     channel.appendLine(`[Warning]: A Cargo.toml file must be at the root of the workspace in order to support all features`)
   }
   let folder = workspaceFolder ? Uri.parse(workspaceFolder.uri).fsPath : workspace.rootPath
+
+  const config = RLSConfiguration.loadFromWorkspace(Uri.parse(Uri.file(folder).toString()).fsPath)
+  if (!config.enable) return;
+
   client = new ClientWorkspace({
     uri: Uri.file(folder).toString(),
     name: path.basename(folder),
-  }, channel)
+  }, config, channel)
   client.start(context).catch(_e => {
     // noop
   })
@@ -58,8 +62,8 @@ class ClientWorkspace {
   public lc: LanguageClient | null = null
   public readonly folder: WorkspaceFolder
 
-  constructor(folder: WorkspaceFolder, private channel: OutputChannel) {
-    this.config = RLSConfiguration.loadFromWorkspace(Uri.parse(folder.uri).fsPath)
+  constructor(folder: WorkspaceFolder, config: RLSConfiguration, private channel: OutputChannel) {
+    this.config = config
     this.folder = folder
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,14 +21,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
     let folder = Uri.parse(workspaceFolder.uri).fsPath
     return fs.existsSync(path.join(folder, 'Cargo.toml'))
   })
-  let channel = window.createOutputChannel('rls')
-  if (!workspaceFolder) {
-    channel.appendLine(`[Warning]: A Cargo.toml file must be at the root of the workspace in order to support all features`)
-  }
   let folder = workspaceFolder ? Uri.parse(workspaceFolder.uri).fsPath : workspace.rootPath
 
   const config = RLSConfiguration.loadFromWorkspace(Uri.parse(Uri.file(folder).toString()).fsPath)
   if (!config.enable) return;
+
+  let channel = window.createOutputChannel('rls')
+  if (!workspaceFolder) {
+    channel.appendLine(`[Warning]: A Cargo.toml file must be at the root of the workspace in order to support all features`)
+  }
 
   client = new ClientWorkspace({
     uri: Uri.file(folder).toString(),


### PR DESCRIPTION
Add a `rust-client.enable` option, as many other sources provide the option and it is missing in this source.

Useful since I want to be able to choose whether or not to use this while not having to remove the files.